### PR TITLE
update vpc source version to v3.11.0 from v3.6.0

### DIFF
--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -2,7 +2,7 @@ data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
-  version = "v3.6.0"
+  version = "v3.11.0"
 
   name = var.name
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
Increases timeout to `5m` for both route table create/update. 