### PR TITLE
feat: add module for ecr repos and replication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ parsednew
 parsed
 
 .vscode/
+testing

--- a/modules/aws/ecr/main.tf
+++ b/modules/aws/ecr/main.tf
@@ -1,0 +1,59 @@
+locals {
+  repositories = var.repositories
+
+  // Note:
+  // 
+  // Providing default values to a list of objects where some of the object key is
+  // optional is an experimental feature and may have breaking changes.
+  // So the default values must be applied via terragrunt template itself as a workaround.
+  // 
+  // Refer: https://www.terraform.io/docs/language/functions/defaults.html
+
+  // repositories = defaults(var.repositories, {
+  //   image_tag_mutability = "MUTABLE"
+  //   scan_on_push         = true
+  //   encryption_type      = "AES256"
+  // })
+}
+
+data "aws_caller_identity" "current" {}
+
+module "ecr" {
+
+  source  = "lgallard/ecr/aws"
+  version = "0.3.2"
+
+  count                = length(local.repositories)
+
+  name                 = local.repositories[count.index].name
+  scan_on_push         = local.repositories[count.index].scan_on_push
+  timeouts_delete      = local.repositories[count.index].timeouts_delete
+  image_tag_mutability = local.repositories[count.index].image_tag_mutability
+  encryption_type      = local.repositories[count.index].encryption_type
+  kms_key              = local.repositories[count.index].kms_key
+
+
+  # Note that currently only one policy may be applied to a repository.
+  policy = local.repositories[count.index].policy
+
+  # Only one lifecycle policy can be used per repository.
+  # To apply multiple rules, combined them in one policy JSON.
+  lifecycle_policy = local.repositories[count.index].lifecycle_policy
+
+}
+
+resource "aws_ecr_replication_configuration" "default" {
+  count = length(var.cross_replication) > 0 ? 1 : 0
+  replication_configuration {
+    rule {
+      dynamic "destination" {
+        for_each = var.cross_replication
+        content {
+          region  = destination.value.region
+          registry_id = data.aws_caller_identity.current.account_id
+        }
+      }
+      
+    }
+  }
+}

--- a/modules/aws/ecr/outputs.tf
+++ b/modules/aws/ecr/outputs.tf
@@ -1,0 +1,7 @@
+output "ecr_repositories" {
+  value = module.ecr
+}
+output "ecr_replication" {
+  value = aws_ecr_replication_configuration.default
+}
+

--- a/modules/aws/ecr/provider.tf
+++ b/modules/aws/ecr/provider.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.64.2"
+    }
+  }
+  // experiments = [module_variable_optional_attrs]
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = var.default_tags
+  }
+}

--- a/modules/aws/ecr/variables.tf
+++ b/modules/aws/ecr/variables.tf
@@ -1,0 +1,32 @@
+variable "default_tags" {
+  description = "Default Tags for s3"
+  type        = map(string)
+}
+
+variable "aws_region" {
+  default     = "us-east-1"
+  description = "Region"
+}
+
+variable "repositories" {
+  type = list(object({
+    name                 = string
+    image_tag_mutability = string
+    scan_on_push         = bool
+    encryption_type      = string
+    kms_key              = string
+    policy               = string
+    timeouts_delete      = string
+    lifecycle_policy     = string
+  }))
+  default     = []
+  description = "Configuration for repositories"
+}
+
+variable "cross_replication" {
+  type = list(object({
+    region = string
+  }))
+  default = []
+  description = "All cross replication inputs"
+}

--- a/templates/infrastructure/account/ecr/terragrunt.hcl
+++ b/templates/infrastructure/account/ecr/terragrunt.hcl
@@ -1,0 +1,56 @@
+
+locals {
+  # Automatically load environment-level variables
+  account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract out common variables for reuse
+  map_users    = local.account_vars.locals.map_users
+  map_accounts = local.account_vars.locals.map_accounts
+
+}
+
+remote_state {
+  backend = "pg" 
+  config = {
+    conn_str = "postgres://{{.BackendData.Username}}:{{.BackendData.Password}}@{{.BackendData.Host}}/{{.Organization.Name}}"
+    schema_name = "tf_{{.Organization.OrganizationID}}_ecr"
+  }
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+}
+
+terraform {
+  # the below config is an example of what the config should like
+  source = "github.com/argonautdev/tf-modules.git//modules/aws/ecr?ref={{.RefVersion}}"
+  # source = "../../../../../../modules/aws/ecr"
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  default_tags = {
+    "argonaut.dev/type"        = "ecr"
+    "argonaut.dev/manager"     = "argonaut.dev"
+  }
+  repositories = [
+    {{range $e := .Ecr.Repositories }}{
+      name                 = "{{$e.Name}}"
+      image_tag_mutability = "{{ if $e.ImageTagMutability }}{{ $e.ImageTagMutability }}{{ else }}MUTABLE{{ end }}"
+      scan_on_push         = {{ if $e.ScanOnPush }}{{ $e.ScanOnPush }}{{ else }}true{{ end }}
+      encryption_type      = "{{ if $e.EncryptionType }}{{ $e.EncryptionType }}{{ else }}AES256{{ end }}"
+      kms_key              = {{ if $e.KmsType }}{{ $e.KmsType }}{{ else }}null{{ end }}
+      timeouts_delete      = "{{ if $e.TimeoutsDelete}}{{ $e.TimeoutsDelete}}{{ else }}60m{{ end }}"
+      policy               = {{if $e.Policy}}{{ $e.Policy }}{{ else }}null{{ end }}
+      lifecycle_policy     = {{if $e.LifecyclePolicy}}{{ $e.LifecyclePolicy }}{{ else }}null{{ end }}
+    },
+    {{end}}
+  ]
+  aws_region                 = "us-east-1"
+  cross_replication = [
+    {{ range $e := .Ecr.Replication }}{
+      region = "{{$e.Region}}"
+    },
+    {{ end }}
+  ]
+}


### PR DESCRIPTION
- adds ecr repos + replication module
- ignore testing folder
- ecr template

Adds module for ecr repos and repication, since the replication is at registry level. This module supports more than one ecr repo.
