### PR TITLE
feat: adds mysql support to rds

### DIFF
--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -1,3 +1,6 @@
+locals {
+  port = var.engine == "postgres" ? 5432 : 3306
+}
 # *** Installs postgres
 
 module "security_group" {
@@ -5,32 +8,32 @@ module "security_group" {
   version = "~> 4"
 
   name        = var.identifier
-  description = "Complete PostgreSQL security group"
+  description = "Complete ${var.engine} security group"
   vpc_id      = var.vpc.vpc_id
 
   # ingress
   
   ingress_with_cidr_blocks = var.visibility == "public" ? [
     {
-      from_port   = 5432
-      to_port     = 5432
+      from_port   = local.port
+      to_port     = local.port
       protocol    = "tcp"
-      description = "PostgreSQL access from within VPC"
+      description = "${var.engine} access from within VPC"
       cidr_blocks = var.vpc.vpc_cidr_block
     },
     {
-      from_port   = 5432
-      to_port     = 5432
+      from_port   = local.port
+      to_port     = local.port
       protocol    = "tcp"
-      description = "Public PostgreSQL access"
+      description = "Public ${var.engine} access"
       cidr_blocks = "0.0.0.0/0"
     },
   ] : [
     {
-      from_port   = 5432
-      to_port     = 5432
+      from_port   = local.port
+      to_port     = local.port
       protocol    = "tcp"
-      description = "PostgreSQL access from within VPC"
+      description = "${var.engine} access from within VPC"
       cidr_blocks = var.vpc.vpc_cidr_block
     },
   ]
@@ -69,20 +72,21 @@ module "db" {
   delete_automated_backups              = false
   deletion_protection                   = false
   iam_database_authentication_enabled   = false
-  license_model                         = "postgresql-license"
+  license_model                         = var.engine == "postgres" ? "postgresql-license" : ""
   maintenance_window                    = "tue:04:29-tue:04:59"
   
   iops                                  = var.iops
   max_allocated_storage                 = var.max_allocated_storage
   multi_az                              = var.multi_az
 
-  port                                  = 5432
+  port                                  = local.port
   publicly_accessible                   = var.visibility == "public" ? "true" : "false"
   storage_encrypted                     = var.storage_encrypted
   storage_type                          = var.storage_type
 
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
-  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+  enabled_cloudwatch_logs_exports = var.engine == "postgres" ? ["postgresql", "upgrade"] :  ["general"]
+
 }
 

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -84,7 +84,7 @@ module "db" {
   storage_encrypted                     = var.storage_encrypted
   storage_type                          = var.storage_type
 
-  performance_insights_enabled          = true
+  performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = 7
   enabled_cloudwatch_logs_exports = var.engine == "postgres" ? ["postgresql", "upgrade"] :  ["general"]
 

--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -105,6 +105,12 @@ variable "iops" {
   default     = 0
 }
 
+variable "performance_insights_enabled" {
+  description = "Enable Performance Insights"
+  type        = bool
+  default     = true
+}
+
 variable "vpc" {
   description = "All vpc info"
   type = object({

--- a/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
+++ b/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
@@ -60,7 +60,7 @@ inputs = {
   identifier     = "{{ .Spec.identifier }}"
   name           = "{{ .Spec.name }}"
 
-  {{if .Spec.engine == "postgres"}}
+  {{if eq .Spec.engine "postgres"}}
   // all values correspond to postgres defaults
   engine         = "{{ .Spec.engine }}"
   engine_version = "{{ .Spec.engine_version }}"
@@ -68,7 +68,7 @@ inputs = {
   major_engine_version       = "postgres13"
   {{end}}
 
-  {{if .Spec.engine == "mysql"}}
+  {{if eq .Spec.engine "mysql"}}
   // all values correspond to mysql defaults
   engine         = "{{ .Spec.engine }}"
   {{if .Spec.engine_version}}engine_version = "{{ .Spec.engine_version }}"{{else}}engine_version = "8.0.26"{{end}}

--- a/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
+++ b/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
@@ -63,9 +63,9 @@ inputs = {
   {{if eq .Spec.engine "postgres"}}
   // all values correspond to postgres defaults
   engine         = "{{ .Spec.engine }}"
-  engine_version = "{{ .Spec.engine_version }}"
-  family       = "{{ .Spec.family }}"
-  major_engine_version       = "postgres13"
+  {{if .Spec.engine_version}}engine_version = "{{ .Spec.engine_version }}"{{end}}
+  {{if .Spec.family}}family       = "{{ .Spec.family }}"{{end}}
+  {{if .Spec.major_engine_version}}major_engine_version       = "{{ .Spec.major_engine_version}}"{{end}}
   {{end}}
 
   {{if eq .Spec.engine "mysql"}}

--- a/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
+++ b/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
@@ -50,6 +50,7 @@ inputs = {
     "argonaut.dev/name"        = "{{ .Spec.name }}"
     "argonaut.dev/type"        = "RDS"
     "argonaut.dev/manager"     = "argonaut.dev"
+    "argonaut.dev/rds-engine"  = "{{ .Spec.engine }}"
     "argonaut.dev/env/${local.env}" = "true"
   }
   aws_region = "${local.region}"
@@ -58,15 +59,27 @@ inputs = {
 
   identifier     = "{{ .Spec.identifier }}"
   name           = "{{ .Spec.name }}"
+
+  {{if .Spec.engine == "postgres"}}
+  // all values correspond to postgres defaults
   engine         = "{{ .Spec.engine }}"
   engine_version = "{{ .Spec.engine_version }}"
+  family       = "{{ .Spec.family }}"
+  major_engine_version       = "postgres13"
+  {{end}}
+
+  {{if .Spec.engine == "mysql"}}
+  // all values correspond to mysql defaults
+  engine         = "{{ .Spec.engine }}"
+  {{if .Spec.engine_version}}engine_version = "{{ .Spec.engine_version }}"{{else}}engine_version = "8.0.26"{{end}}
+  {{if .Spec.family}}family       = "{{ .Spec.family }}"{{else}}family       = "mysql8.0"{{end}}
+  {{if .Spec.major_engine_version}}major_engine_version       = "{{ .Spec.major_engine_version }}"{{else}}major_engine_version       = "8.0"{{end}}
+  {{end}}
 
   storage        = {{ .Spec.storage }}
   instance_class = "{{ .Spec.instance_class }}"
   username       = "{{ .Spec.username }}"
   password       = "{{ .Spec.password }}"
-  family       = "{{ .Spec.family }}"
-  major_engine_version       = "postgres13"
   db_subnet_group_name = "{{ .Spec.name }}-db-subnet"
 
   vpc = {

--- a/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
+++ b/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
@@ -74,6 +74,7 @@ inputs = {
   {{if .Spec.engine_version}}engine_version = "{{ .Spec.engine_version }}"{{else}}engine_version = "8.0.26"{{end}}
   {{if .Spec.family}}family       = "{{ .Spec.family }}"{{else}}family       = "mysql8.0"{{end}}
   {{if .Spec.major_engine_version}}major_engine_version       = "{{ .Spec.major_engine_version }}"{{else}}major_engine_version       = "8.0"{{end}}
+  {{if and (ne .Spec.instance_class "db.t2.micro") (ne .Spec.instance_class "db.t2.small") (ne .Spec.instance_class "db.t3.micro") (ne .Spec.instance_class "db.t3.small")}}performance_insights_enabled=false{{else}}performance_insights_enabled=true{{end}}
   {{end}}
 
   storage        = {{ .Spec.storage }}

--- a/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
+++ b/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
@@ -61,7 +61,7 @@ inputs = {
   name           = "{{ .Spec.name }}"
 
   {{if eq .Spec.engine "postgres"}}
-  // all values correspond to postgres defaults
+  // all values correspond to postgres
   engine         = "{{ .Spec.engine }}"
   {{if .Spec.engine_version}}engine_version = "{{ .Spec.engine_version }}"{{end}}
   {{if .Spec.family}}family       = "{{ .Spec.family }}"{{end}}
@@ -69,7 +69,7 @@ inputs = {
   {{end}}
 
   {{if eq .Spec.engine "mysql"}}
-  // all values correspond to mysql defaults
+  // all values correspond to mysql
   engine         = "{{ .Spec.engine }}"
   {{if .Spec.engine_version}}engine_version = "{{ .Spec.engine_version }}"{{else}}engine_version = "8.0.26"{{end}}
   {{if .Spec.family}}family       = "{{ .Spec.family }}"{{else}}family       = "mysql8.0"{{end}}

--- a/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
+++ b/templates/infrastructure/account/tfEnvironment/tfRegion/rds/terragrunt.hcl
@@ -74,7 +74,7 @@ inputs = {
   {{if .Spec.engine_version}}engine_version = "{{ .Spec.engine_version }}"{{else}}engine_version = "8.0.26"{{end}}
   {{if .Spec.family}}family       = "{{ .Spec.family }}"{{else}}family       = "mysql8.0"{{end}}
   {{if .Spec.major_engine_version}}major_engine_version       = "{{ .Spec.major_engine_version }}"{{else}}major_engine_version       = "8.0"{{end}}
-  {{if and (ne .Spec.instance_class "db.t2.micro") (ne .Spec.instance_class "db.t2.small") (ne .Spec.instance_class "db.t3.micro") (ne .Spec.instance_class "db.t3.small")}}performance_insights_enabled=false{{else}}performance_insights_enabled=true{{end}}
+  {{if or (eq .Spec.instance_class "db.t2.micro") (eq .Spec.instance_class "db.t2.small") (eq .Spec.instance_class "db.t3.micro") (eq .Spec.instance_class "db.t3.small")}}performance_insights_enabled=false{{else}}performance_insights_enabled=true{{end}}
   {{end}}
 
   storage        = {{ .Spec.storage }}


### PR DESCRIPTION
Following changes are made
- Mysql or postgres is created based on the engine version.
- For mysql, performance_insights aren't available for `db.t2.micro`, `db.t2.small`, `db.t3.micro` and `db.t3.small`.