### PR TITLE
Removed resource which creates mongodb atlas network peering container

### DIFF
--- a/modules/aws/mongo_atlas_vpc_peering/main.tf
+++ b/modules/aws/mongo_atlas_vpc_peering/main.tf
@@ -9,22 +9,15 @@ resource "mongodbatlas_project" "aws_atlas" {
   org_id = var.atlas_org_id
 }
 
-resource "mongodbatlas_network_container" "atlas_container" {
-  atlas_cidr_block = var.atlas_vpc_cidr
-  project_id       = mongodbatlas_project.aws_atlas.id
-  provider_name    = "AWS"
-  region_name      = var.atlas_region
-}
-
 data "mongodbatlas_network_container" "atlas_container" {
-  container_id = mongodbatlas_network_container.atlas_container.container_id
+  container_id = var.atlas_container_id
   project_id   = mongodbatlas_project.aws_atlas.id
 }
 
 resource "mongodbatlas_network_peering" "aws-atlas" {
   accepter_region_name   = var.aws_region
   project_id             = mongodbatlas_project.aws_atlas.id
-  container_id           = mongodbatlas_network_container.atlas_container.container_id
+  container_id           = var.atlas_container_id
   provider_name          = "AWS"
   route_table_cidr_block = data.aws_vpc.primary.cidr_block
   vpc_id                 = data.aws_vpc.primary.id

--- a/modules/aws/mongo_atlas_vpc_peering/variables.tf
+++ b/modules/aws/mongo_atlas_vpc_peering/variables.tf
@@ -5,39 +5,44 @@ variable "aws_region" {
 
 variable "vpc" {
   description = "All vpc info"
-  type = object({
-    name = string
-    vpc_id   = string
+  type        = object({
+    name   = string
+    vpc_id = string
   })
 }
 
 variable "atlas_public_key" {
-  type = string
+  type        = string
   description = "The public API key for MongoDB Atlas"
 }
 
 variable "atlas_private_key" {
-  type = string
+  type        = string
   description = "The private API key for MongoDB Atlas"
 }
 
 variable "atlas_region" {
-  type = string
+  type        = string
   description = "Atlas Region"
 }
 
 variable "atlas_org_id" {
   description = "Atlas Org ID"
-  type = string
+  type        = string
 }
 
 variable "atlas_vpc_cidr" {
   description = "Atlas CIDR"
-  type = string
+  type        = string
 }
 
 variable "atlas_project_name" {
   description = "MongoDB Atlas project name"
+  type        = string
+}
+
+variable "atlas_container_id" {
+  description = "MongoDB Atlas network container id"
   type        = string
 }
 

--- a/templates/infrastructure/account/tfEnvironment/tfRegion/mongo_atlas_vpc_peering/terragrunt.hcl
+++ b/templates/infrastructure/account/tfEnvironment/tfRegion/mongo_atlas_vpc_peering/terragrunt.hcl
@@ -5,9 +5,9 @@ include {
 locals {
   # Automatically load environment-level variables
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
-  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
 
-  env = local.environment_vars.locals.environment
+  env    = local.environment_vars.locals.environment
   region = local.region_vars.locals.aws_region
 }
 
@@ -19,8 +19,8 @@ terraform {
 }
 
 dependency "vpc" {
-  config_path = "../vpc"
-   mock_outputs = {
+  config_path  = "../vpc"
+  mock_outputs = {
     vpc_id = "temporary-dummy-id",
   }
 }
@@ -30,21 +30,22 @@ inputs = {
   aws_region = "${local.region}"
 
   vpc = {
-    name    = "${local.env}"
-    vpc_id      = dependency.vpc.outputs.vpc_id
+    name   = "${local.env}"
+    vpc_id = dependency.vpc.outputs.vpc_id
   }
 
-  atlas_public_key="{{.Spec.atlas_public_key}}"
-  atlas_private_key="{{.Spec.atlas_private_key}}"
-  atlas_region="{{.Spec.atlas_region}}"
-  atlas_org_id="{{.Spec.atlas_org_id}}"
-  atlas_vpc_cidr="{{.Spec.atlas_vpc_cidr}}"
-  atlas_project_name="{{.Spec.atlas_project_name}}"
+  atlas_public_key   = "{{.Spec.atlas_public_key}}"
+  atlas_private_key  = "{{.Spec.atlas_private_key}}"
+  atlas_region       = "{{.Spec.atlas_region}}"
+  atlas_org_id       = "{{.Spec.atlas_org_id}}"
+  atlas_vpc_cidr     = "{{.Spec.atlas_vpc_cidr}}"
+  atlas_project_name = "{{.Spec.atlas_project_name}}"
+  atlas_container_id = "{{.Spec.atlas_container_id}}"
 
   default_tags = {
-    "argonaut.dev/name" = "{{.Spec.name}}"
-    "argonaut.dev/manager" = "argonaut.dev"
-    "argonaut.dev/type" = "MongoDB-Atlas-VPC-Peering"
+    "argonaut.dev/name"             = "{{.Spec.name}}"
+    "argonaut.dev/manager"          = "argonaut.dev"
+    "argonaut.dev/type"             = "MongoDB-Atlas-VPC-Peering"
     "argonaut.dev/env/${local.env}" = "true"
   }
 }


### PR DESCRIPTION
Removed resource which creates mongodb atlas network peering container
Added atlas_container_id field to accept existing container id from terragrunt

This change is associated with PR:  https://github.com/argonautdev/midgard/pull/472