### PR TITLE
feat(iam): add support for IAM roles when provisioning eks

### DIFF
--- a/modules/aws/eks/locals.tf
+++ b/modules/aws/eks/locals.tf
@@ -1,3 +1,0 @@
-locals {
-  k8s_service_account_namespace = "kube-system"
-}

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -90,7 +90,7 @@ module "iam_assumable_role_admin" {
   role_name                     = "${data.aws_eks_cluster.cluster.name}-role"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.k8s_service_account_namespace}:${var.k8s_service_account_name}"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.k8s_service_account_namespace}:${var.k8s_service_account_name}"]
 }
 
 resource "aws_iam_policy" "cluster_autoscaler" {

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -17,12 +17,12 @@ data "aws_availability_zones" "available" {
 }
 
 module "eks" {
-  source          = "terraform-aws-modules/eks/aws"
-  version = "v17.4.0"
-  cluster_name    = var.cluster.name
-  cluster_version = var.cluster.version
+  source                   = "terraform-aws-modules/eks/aws"
+  version                  = "v17.4.0"
+  cluster_name             = var.cluster.name
+  cluster_version          = var.cluster.version
   wait_for_cluster_timeout = 900
-  subnets         = var.vpc.subnets
+  subnets                  = var.vpc.subnets
 
   vpc_id = var.vpc.id
 
@@ -34,7 +34,7 @@ module "eks" {
   node_groups = {
     "${var.cluster.name}" = {
       # "
-      name_prefix = "${var.cluster.name}-art-"
+      name_prefix      = "${var.cluster.name}-art-"
       desired_capacity = var.node_group.desired_capacity
       max_capacity     = var.node_group.max_capacity
       min_capacity     = var.node_group.min_capacity
@@ -47,7 +47,7 @@ module "eks" {
       }
 
       additional_tags = var.node_group.spot ? merge(var.default_tags, var.spot_tags) : merge(var.default_tags, var.on_demand_tags)
-      taints = []
+      taints          = []
     }
   }
 
@@ -68,17 +68,17 @@ module "eks" {
   #   }
   # ]
 
-  map_roles = [
+  map_roles = concat(var.map_roles, [
     {
       rolearn  = aws_iam_role.eks_admin_role.arn
       username = "aws_iam_auth_admin"
-      groups   = [
+      groups = [
         "system:masters",
         "system:bootstrappers",
         "system:nodes"
       ]
     }
-  ]
+  ])
   map_users    = var.map_users
   map_accounts = var.map_accounts
 }
@@ -148,12 +148,12 @@ resource "aws_iam_role" "eks_admin_role" {
   description = "Kubernetes administrator role (for AWS IAM Group based Auth for Kubernetes)"
 
   assume_role_policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = [
       {
-        Action    = "sts:AssumeRole"
-        Effect    = "Allow"
-        Sid       = ""
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
         Principal = {
           AWS = "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root"
         }
@@ -171,7 +171,7 @@ resource "aws_iam_group_policy" "eks_admin_group_policy" {
   group = aws_iam_group.eks_admin_group.name
 
   policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = [
       {
         Action   = "sts:AssumeRole"

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -86,3 +86,8 @@ variable "ami_type" {
   default = "AL2_x86_64"
   type    = string
 }
+
+variables "k8s_service_account_namespace" {
+  default = "tools"
+  type    = string
+}

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -25,11 +25,11 @@ variable "map_accounts" {
 variable "cluster" {
   description = "All cluster info (singular)"
   type = object({
-    name = string
+    name    = string
     version = string
   })
   default = {
-    name = "argonaut"
+    name    = "argonaut"
     version = "1.21"
   }
 }
@@ -37,8 +37,8 @@ variable "cluster" {
 variable "vpc" {
   description = "All vpc info"
   type = object({
-    name = string
-    id   = string
+    name    = string
+    id      = string
     subnets = list(string)
   })
 }
@@ -46,13 +46,13 @@ variable "vpc" {
 variable "node_group" {
   description = "All node_group info (singular)"
   type = object({
-    name_prefix = string 
+    name_prefix      = string
     desired_capacity = number
-    max_capacity = number
-    min_capacity = number
-    disk_size = number
-    instance_type = string
-    spot = bool
+    max_capacity     = number
+    min_capacity     = number
+    disk_size        = number
+    instance_type    = string
+    spot             = bool
   })
 }
 
@@ -63,7 +63,15 @@ variable "map_users" {
     username = string
     groups   = list(string)
   }))
+}
 
+variable "map_roles" {
+  description = "Additional IAM roles to add to the aws-auth configmap."
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
 }
 
 variable "env" {
@@ -76,5 +84,5 @@ variable "k8s_service_account_name" {
 
 variable "ami_type" {
   default = "AL2_x86_64"
-  type = string
+  type    = string
 }

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -87,7 +87,7 @@ variable "ami_type" {
   type    = string
 }
 
-variables "k8s_service_account_namespace" {
+variable "k8s_service_account_namespace" {
   default = "tools"
   type    = string
 }

--- a/templates/infrastructure/account/account.hcl
+++ b/templates/infrastructure/account/account.hcl
@@ -4,7 +4,7 @@
 locals {
   map_roles = [
     {
-      rolearn = "{{.AWS.AWSRole}}"
+      rolearn = "{{.AWS.AWSArn}}"
       username = "system:masters"
       groups = ["system:masters"]
     }

--- a/templates/infrastructure/account/account.hcl
+++ b/templates/infrastructure/account/account.hcl
@@ -3,18 +3,22 @@
 // account level specs kept here
 locals {
   map_roles = [
+    {{ if .AWS.AWSRoleArn }}
     {
-      rolearn = "{{.AWS.AWSArn}}"
+      rolearn = "{{.AWS.AWSRoleArn}}"
       username = "system:masters"
       groups = ["system:masters"]
     }
+    {{ end }}
   ]
   map_users = [
+    {{ if .AWS.AWSArn }}
     {
       userarn = "{{.AWS.AWSArn}}"
       username = "{{.AWS.Username}}"
       groups = ["system:masters"]
     }
+    {{ end }}
   ]
   map_accounts = ["{{.AWS.AWSAccountID}}"]
 }

--- a/templates/infrastructure/account/account.hcl
+++ b/templates/infrastructure/account/account.hcl
@@ -2,6 +2,13 @@
 # terragrunt.hcl configuration
 // account level specs kept here
 locals {
+  map_roles = [
+    {
+      rolearn = "{{.AWS.AWSRole}}"
+      username = "system:masters"
+      groups = ["system:masters"]
+    }
+  ]
   map_users = [
     {
       userarn = "{{.AWS.AWSArn}}"

--- a/templates/infrastructure/account/tfEnvironment/tfRegion/eks/terragrunt.hcl
+++ b/templates/infrastructure/account/tfEnvironment/tfRegion/eks/terragrunt.hcl
@@ -11,6 +11,7 @@ locals {
   # Extract out common variables for reuse
   map_users = local.account_vars.locals.map_users
   map_accounts = local.account_vars.locals.map_accounts
+  map_roles = local.account_vars.locals.map_roles
 
   env = local.environment_vars.locals.environment
 
@@ -96,6 +97,7 @@ inputs = {
   # account level spec kept at account level
   map_users = local.map_users
   map_accounts = local.map_accounts
+  map_roles = local.map_roles
 
   aws_region = "${local.region}"
 }


### PR DESCRIPTION
#### Feats
- Add user in `map_users` if static keys are present, this change is required since the existing users might be unable to do operations on their cluster with their static keys
- Add role in `map_roles` if IAM connection is present
- Add OIDC trust in `tools` namespace by default not `kube-system`