### PR TITLE
EKS NodeGroup upgrade along with cluster

### DIFF
--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -30,6 +30,7 @@ locals {
     capacity_type = v.spot ? "SPOT" : "ON_DEMAND"
     instance_types = [v.instance_type]
     name_prefix   = "${v.ng_name}-art-"
+    ami_release_version = var.cluster.version
     k8s_labels = merge(v.k8s_labels, { Environment = var.env })
   }, v)}
 }

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -13,6 +13,10 @@ provider "kubernetes" {
   # load_config_file       = false
 }
 
+data "aws_availability_zones" "available" {
+}
+
+
 ##The intention is to take list of nodegroups and convert into the format node_groups expects i.e map()
 ##However, for_each loop only works inside a resource block and cannot do any operation inside node_groups variable
 ##Hence, creating a null resource and convert the variable from list to map and reference in node_groups variable

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -13,10 +13,6 @@ provider "kubernetes" {
   # load_config_file       = false
 }
 
-data "aws_availability_zones" "available" {
-}
-
-
 ##The intention is to take list of nodegroups and convert into the format node_groups expects i.e map()
 ##However, for_each loop only works inside a resource block and cannot do any operation inside node_groups variable
 ##Hence, creating a null resource and convert the variable from list to map and reference in node_groups variable
@@ -30,7 +26,7 @@ locals {
     capacity_type = v.spot ? "SPOT" : "ON_DEMAND"
     instance_types = [v.instance_type]
     name_prefix   = "${v.ng_name}-art-"
-    ami_release_version = var.cluster.version
+    version = var.cluster.version
     k8s_labels = merge(v.k8s_labels, { Environment = var.env })
   }, v)}
 }


### PR DESCRIPTION
This enhancement helps in the following cases. 
    1. Pass Version to Nodegroup. 
    2. If we want to Update ng along with cluster.  