### PR TITLE
fix: anchored gke version to `1.24` form `latest`

### DIFF
--- a/modules/gcp/gke/variables.tf
+++ b/modules/gcp/gke/variables.tf
@@ -127,7 +127,7 @@ variable "horizontal_pod_autoscaling" {
 variable "kubernetes_version" {
   type        = string
   description = "The Kubernetes version of the masters."
-  default     = "latest"
+  default     = "1.24"
 }
 
 variable "initial_node_count" {


### PR DESCRIPTION
Fixes default GKE version to `1.24` instead of the `latest` tag.