### PR TITLE
Spot support for GKE Nodepool

### DIFF
--- a/modules/gcp/gke/main.tf
+++ b/modules/gcp/gke/main.tf
@@ -39,7 +39,7 @@ resource "google_compute_subnetwork" "cluster_subnet" {
 
 module "gke" {
   depends_on = [google_compute_subnetwork.cluster_subnet]
-  source = "github.com/argonautdev/terraform-google-kubernetes-engine//modules/private-cluster?ref=v21.1.5"
+  source = "github.com/argonautdev/terraform-google-kubernetes-engine//modules/private-cluster?ref=v21.1.6"
   project_id                      = var.project_id
   name                            = var.cluster_name
   description                     = var.description

--- a/modules/gcp/gke/provider.tf
+++ b/modules/gcp/gke/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.22.0"
+      version = "4.25.0"
     }
   }
 }

--- a/modules/gcp/gke/variables.tf
+++ b/modules/gcp/gke/variables.tf
@@ -164,6 +164,7 @@ variable "node_pools" {
       auto_repair = optional(bool),
       auto_upgrade = bool,
       preemptible = optional(bool),
+      spot = optional(bool),
       enable_gcfs = bool,##Set to true only if image streaming is required.
       accelerator_type = optional(string),
       accelerator_count = optional(number),
@@ -178,6 +179,7 @@ variable "node_pools" {
       image_type      = "COS_CONTAINERD"
       autoscaling     = false
       auto_upgrade    = false,
+      spot    = false,
       enable_gcfs     = false
     }
   ]


### PR DESCRIPTION
Provider Version Changed from 4.22 to 4.25 as spot GA is available in that version. 
Modified Upstream module to use spot and is bydefault set to false