### PR TITLE
Adding missing permissions to cluster autoscaler

### DIFF
--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -104,6 +104,7 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeTags",
+      "eks:DescribeNodegroup",
       "ec2:DescribeLaunchTemplateVersions",
     ]
 


### PR DESCRIPTION
Updated the ClusterAutoscaler Role Permissions required for cluster autoscaler 1.27... 

Tested Backward compatibility too.. 