### PR TITLE
fix: vpc creation fails because of unexpected variables

### DIFF
--- a/modules/aws/vpc/default/provider.tf
+++ b/modules/aws/vpc/default/provider.tf
@@ -1,5 +1,12 @@
 terraform {
   required_version = ">= 0.15"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67.0"
+    }
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
VPC creates are failing my guess is that the required provider blocks in the upstream module which is

```terraform
terraform {
  required_version = ">= 0.13.1"

  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = ">= 3.63"
    }
  }
}
```
is picking up the latest provider version upstream (`5.x.x`). This is causing issues (my guess is move from 4 to 5 had breaking changes). We should be more pessimistic about version upgrades. I changed it to `4.67.x` (only patches will be allowed). `4.67` is the latest in the `4` series and it is working for us. I can't change it to `3.64.x` because downgrading might not be backwards compatible.

Similar issue might happen with other modules as well, so we need to pin their version as well.